### PR TITLE
ci: add deploy workflow for branch-based deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy from branch
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: temurin
+      - name: Lint
+        run: ./gradlew spotlessCheck
+      - name: Test
+        run: ./gradlew test
+
+  deploy:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+    needs: [test]
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: temurin
+      - name: push gem
+        uses: trocco-io/push-gem-to-gpr-action@v1
+        with:
+          language: java
+          gem-path: "./build/gems/*.gem"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow (`deploy.yml`) for deploying from a specific branch via manual trigger
- Run from GitHub UI: Actions → Deploy from branch → Run workflow → select branch
- Builds and publishes gem after test (lint + test) passes

## Background
- Needed for canary-releasing the fix for #42731 from a feature branch
- The existing `main.yml` skips the test job on `workflow_dispatch`, causing the build job to also be skipped due to `needs: [test]`

## Changes
- Add `.github/workflows/deploy.yml`
- No changes to existing `main.yml`

## Test plan
- [ ] Trigger the workflow manually from a feature branch and verify it runs test → deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)