### PR TITLE
fix: prevent data duplication during TD job result download retry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,14 @@ dependencies {
     implementation "com.google.inject:guice:7.0.0"
 
     implementation project(path: ":shadow-td-client", configuration: "shadow")
+
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "org.mockito:mockito-core:3.11.2"
+    testImplementation "org.embulk:embulk-api:${embulkVersion}"
+    testImplementation "org.embulk:embulk-spi:${embulkVersion}"
+    testImplementation "org.embulk:embulk-core:${embulkVersion}"
+    testImplementation "org.embulk:embulk-deps:${embulkVersion}"
+    testImplementation "org.embulk:embulk-junit4:${embulkVersion}"
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/src/main/java/org/embulk/input/td/TdInputPlugin.java
+++ b/src/main/java/org/embulk/input/td/TdInputPlugin.java
@@ -15,6 +15,9 @@ import com.treasuredata.client.model.TDJobSummary;
 import com.treasuredata.client.model.TDResultFormat;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -349,55 +352,81 @@ public class TdInputPlugin
         try (final PageBuilder pageBuilder = new PageBuilder(allocator, schema, output);
              final TDClient client = newTdClient(task)) {
             final TDResultFormat resultFormat = TDResultFormat.MESSAGE_PACK_GZ;
-            client.jobResult(jobId, resultFormat, new Function<InputStream, Void>() {
-                @Override
-                public Void apply(InputStream input) {
-                    try (final MessageUnpacker unpacker = MessagePack
-                            .newDefaultUnpacker(new GZIPInputStream(input))) {
-                        while (unpacker.hasNext()) {
-                            try {
-                                final Value v;
-                                try {
-                                    v = unpacker.unpackValue();
-                                } catch (IOException e) {
-                                    throw new InvalidRecordException("Cannot unpack value", e);
-                                }
 
-                                if (!v.isArrayValue()) {
-                                    throw new InvalidRecordException(
-                                            String.format(Locale.ENGLISH,
-                                                    "Must be array value: (%s)", v.toString()));
-                                }
-
-                                final ArrayValue record = v.asArrayValue();
-                                if (record.size() != schema.size()) {
-                                    throw new InvalidRecordException(String.format(Locale.ENGLISH,
-                                            "The size (%d) of the record is invalid",
-                                            record.size()));
-                                }
-
-                                // write records to the page
-                                for (int i = 0; i < writers.length; i++) {
-                                    writers[i].write(record.get(i), pageBuilder);
-                                }
-
-                                pageBuilder.addRecord();
-                            } catch (InvalidRecordException e) {
-                                if (stopOnInvalidRecord) {
-                                    throw new DataException(String.format(Locale.ENGLISH,
-                                            "Invalid record (%s)", e.getMessage()), e);
-                                }
-                                log.warn(String.format(Locale.ENGLISH,
-                                        "Skipped record (%s)", e.getMessage()));
-                            }
+            // Phase 1: Download job result to a temporary file.
+            // This separates network I/O (where td-client-java retry is needed) from
+            // data processing (where retry would cause duplicate records).
+            // On retry, Files.copy with REPLACE_EXISTING overwrites partial data,
+            // preventing duplication. See: https://github.com/primenumber-dev/n-transfer-ui/issues/42731
+            Path tempFile = null;
+            try {
+                tempFile = Files.createTempFile("embulk-input-td.", ".msgpack.gz");
+                final Path tempFilePath = tempFile;
+                client.jobResult(jobId, resultFormat, new Function<InputStream, Void>() {
+                    @Override
+                    public Void apply(InputStream input) {
+                        try {
+                            Files.copy(input, tempFilePath, StandardCopyOption.REPLACE_EXISTING);
+                        } catch (IOException e) {
+                            throw Throwables.propagate(e);
                         }
-                    } catch (IOException e) {
-                        throw Throwables.propagate(e);
+                        return null;
                     }
+                });
 
-                    return null;
+                // Phase 2: Read from the local temporary file and write to PageBuilder.
+                // No network errors can occur here since we are reading from a local file.
+                try (final MessageUnpacker unpacker = MessagePack
+                        .newDefaultUnpacker(new GZIPInputStream(Files.newInputStream(tempFile)))) {
+                    while (unpacker.hasNext()) {
+                        try {
+                            final Value v;
+                            try {
+                                v = unpacker.unpackValue();
+                            } catch (IOException e) {
+                                throw new InvalidRecordException("Cannot unpack value", e);
+                            }
+
+                            if (!v.isArrayValue()) {
+                                throw new InvalidRecordException(
+                                        String.format(Locale.ENGLISH,
+                                                "Must be array value: (%s)", v.toString()));
+                            }
+
+                            final ArrayValue record = v.asArrayValue();
+                            if (record.size() != schema.size()) {
+                                throw new InvalidRecordException(String.format(Locale.ENGLISH,
+                                        "The size (%d) of the record is invalid",
+                                        record.size()));
+                            }
+
+                            // write records to the page
+                            for (int i = 0; i < writers.length; i++) {
+                                writers[i].write(record.get(i), pageBuilder);
+                            }
+
+                            pageBuilder.addRecord();
+                        } catch (InvalidRecordException e) {
+                            if (stopOnInvalidRecord) {
+                                throw new DataException(String.format(Locale.ENGLISH,
+                                        "Invalid record (%s)", e.getMessage()), e);
+                            }
+                            log.warn(String.format(Locale.ENGLISH,
+                                    "Skipped record (%s)", e.getMessage()));
+                        }
+                    }
                 }
-            });
+            } catch (IOException e) {
+                throw Throwables.propagate(e);
+            } finally {
+                if (tempFile != null) {
+                    try {
+                        Files.deleteIfExists(tempFile);
+                    } catch (IOException e) {
+                        log.warn("Failed to delete temporary file: " + tempFile, e);
+                    }
+                }
+            }
 
             pageBuilder.finish();
         }

--- a/src/test/java/org/embulk/input/td/TestTdInputPlugin.java
+++ b/src/test/java/org/embulk/input/td/TestTdInputPlugin.java
@@ -1,4 +1,228 @@
 package org.embulk.input.td;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import com.google.common.base.Function;
+import com.google.common.base.Throwables;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for the temporary file download mechanism in TdInputPlugin.
+ *
+ * The core fix (https://github.com/primenumber-dev/n-transfer-ui/issues/42731) separates
+ * network I/O from data processing by downloading to a temp file first.
+ * These tests verify that:
+ * 1. Data is correctly written to and read from the temp file
+ * 2. On retry (callback invoked multiple times), REPLACE_EXISTING prevents data duplication
+ * 3. The temp file is cleaned up after processing
+ */
 public class TestTdInputPlugin {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    /**
+     * Simulates the callback logic used in TdInputPlugin.run() Phase 1.
+     * Downloads the input stream to a temp file using Files.copy with REPLACE_EXISTING.
+     */
+    private static void downloadToTempFile(InputStream input, Path tempFile) {
+        try {
+            Files.copy(input, tempFile, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Test
+    public void testDownloadToTempFile_normalCase() throws Exception {
+        byte[] data = "hello world".getBytes();
+        Path tempFile = tempFolder.newFile("test.msgpack.gz").toPath();
+
+        downloadToTempFile(new ByteArrayInputStream(data), tempFile);
+
+        byte[] result = Files.readAllBytes(tempFile);
+        assertArrayEquals(data, result);
+    }
+
+    @Test
+    public void testDownloadToTempFile_retryOverwritesPreviousData() throws Exception {
+        // Simulates the retry scenario:
+        // 1st attempt: partial data written, then IOException
+        // 2nd attempt: full data written successfully
+        // REPLACE_EXISTING should overwrite the partial data from the 1st attempt
+
+        Path tempFile = tempFolder.newFile("test.msgpack.gz").toPath();
+
+        // 1st attempt: write partial data (simulates successful partial download before network error)
+        byte[] partialData = "partial data from first attempt".getBytes();
+        downloadToTempFile(new ByteArrayInputStream(partialData), tempFile);
+
+        // Verify partial data is on disk
+        assertEquals(partialData.length, Files.size(tempFile));
+
+        // 2nd attempt (retry): write full data with REPLACE_EXISTING
+        byte[] fullData = "complete data".getBytes();
+        downloadToTempFile(new ByteArrayInputStream(fullData), tempFile);
+
+        // Verify the file contains ONLY the full data, not partial + full
+        byte[] result = Files.readAllBytes(tempFile);
+        assertArrayEquals(fullData, result);
+        assertEquals(fullData.length, Files.size(tempFile));
+    }
+
+    @Test
+    public void testDownloadToTempFile_retryWithLargerPartialData() throws Exception {
+        // Edge case: 1st attempt writes MORE data than the 2nd attempt
+        // REPLACE_EXISTING should still correctly overwrite
+
+        Path tempFile = tempFolder.newFile("test.msgpack.gz").toPath();
+
+        // 1st attempt: large partial data
+        byte[] largePartialData = new byte[10000];
+        for (int i = 0; i < largePartialData.length; i++) {
+            largePartialData[i] = (byte) (i % 256);
+        }
+        downloadToTempFile(new ByteArrayInputStream(largePartialData), tempFile);
+        assertEquals(10000, Files.size(tempFile));
+
+        // 2nd attempt (retry): smaller complete data
+        byte[] smallFullData = "small but complete".getBytes();
+        downloadToTempFile(new ByteArrayInputStream(smallFullData), tempFile);
+
+        byte[] result = Files.readAllBytes(tempFile);
+        assertArrayEquals(smallFullData, result);
+        assertEquals(smallFullData.length, Files.size(tempFile));
+    }
+
+    @Test
+    public void testDownloadToTempFile_multipleRetries() throws Exception {
+        // Simulates multiple retries (td-client-java retryLimit defaults to 7)
+        Path tempFile = tempFolder.newFile("test.msgpack.gz").toPath();
+
+        // Simulate 3 failed attempts with increasing partial data
+        for (int attempt = 1; attempt <= 3; attempt++) {
+            byte[] partialData = new byte[attempt * 1000];
+            for (int i = 0; i < partialData.length; i++) {
+                partialData[i] = (byte) attempt;
+            }
+            downloadToTempFile(new ByteArrayInputStream(partialData), tempFile);
+        }
+
+        // Final successful attempt
+        byte[] finalData = "final successful download".getBytes();
+        downloadToTempFile(new ByteArrayInputStream(finalData), tempFile);
+
+        byte[] result = Files.readAllBytes(tempFile);
+        assertArrayEquals(finalData, result);
+    }
+
+    @Test
+    public void testDownloadToTempFile_streamErrorMidway() throws Exception {
+        // Simulates IOException occurring mid-stream (e.g., network disconnection)
+        Path tempFile = tempFolder.newFile("test.msgpack.gz").toPath();
+
+        // Create a stream that throws IOException after reading some bytes
+        byte[] partialData = "some data before error".getBytes();
+        InputStream failingStream = new InputStream() {
+            private final ByteArrayInputStream delegate = new ByteArrayInputStream(partialData);
+            private int bytesRead = 0;
+
+            @Override
+            public int read() throws IOException {
+                if (bytesRead >= partialData.length / 2) {
+                    throw new IOException("Simulated network error");
+                }
+                bytesRead++;
+                return delegate.read();
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException {
+                if (bytesRead >= partialData.length / 2) {
+                    throw new IOException("Simulated network error");
+                }
+                int n = delegate.read(b, off, Math.min(len, partialData.length / 2 - bytesRead));
+                if (n > 0) {
+                    bytesRead += n;
+                }
+                return n;
+            }
+        };
+
+        // 1st attempt: fails mid-stream
+        try {
+            downloadToTempFile(failingStream, tempFile);
+        } catch (RuntimeException e) {
+            // Expected: Throwables.propagate wraps IOException
+        }
+
+        // 2nd attempt (retry): succeeds with complete data
+        byte[] completeData = "complete data after retry".getBytes();
+        downloadToTempFile(new ByteArrayInputStream(completeData), tempFile);
+
+        // Verify only the complete data is present
+        byte[] result = Files.readAllBytes(tempFile);
+        assertArrayEquals(completeData, result);
+    }
+
+    @Test
+    public void testTempFileCleanup() throws Exception {
+        // Verify temp file is deleted in the finally block pattern used in TdInputPlugin
+        Path tempFile = Files.createTempFile("embulk-input-td.", ".msgpack.gz");
+        try {
+            byte[] data = "test data".getBytes();
+            downloadToTempFile(new ByteArrayInputStream(data), tempFile);
+        } finally {
+            if (tempFile != null) {
+                Files.deleteIfExists(tempFile);
+            }
+        }
+
+        assertFalse("Temp file should be deleted", Files.exists(tempFile));
+    }
+
+    @Test
+    public void testCallbackInvokedMultipleTimes_simulatesRetryBehavior() throws Exception {
+        // Simulates the actual td-client-java retry mechanism:
+        // submitRequest() calls the callback, and on failure, retries by calling it again
+        Path tempFile = tempFolder.newFile("test.msgpack.gz").toPath();
+
+        final AtomicInteger callCount = new AtomicInteger(0);
+        final byte[] correctData = "correct complete data".getBytes();
+
+        Function<InputStream, Void> callback = new Function<InputStream, Void>() {
+            @Override
+            public Void apply(InputStream input) {
+                try {
+                    Files.copy(input, tempFile, StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException e) {
+                    throw Throwables.propagate(e);
+                }
+                return null;
+            }
+        };
+
+        // Simulate: 1st call with partial data (before retry)
+        callback.apply(new ByteArrayInputStream("partial".getBytes()));
+        callCount.incrementAndGet();
+
+        // Simulate: 2nd call with correct data (after retry)
+        callback.apply(new ByteArrayInputStream(correctData));
+        callCount.incrementAndGet();
+
+        assertEquals(2, callCount.get());
+        byte[] result = Files.readAllBytes(tempFile);
+        assertArrayEquals(correctData, result);
+    }
 }


### PR DESCRIPTION
## Summary
- Download TD job results to a temporary file before processing with PageBuilder
- Separates network I/O (retryable) from data processing (not retryable), preventing data duplication on retry
- Add unit tests for the temp file download mechanism

## Background
When transferring large datasets (400M+ records) from Treasure Data, network errors during stream reading triggered td-client-java's retry mechanism. Since PageBuilder was not reset on retry, already-flushed pages remained in the output pipeline, causing data duplication (up to 8x in the worst case with 7 retries).

Root cause: `TDHttpClient.submitRequest()` includes the `onSuccess` callback within its retry scope, so exceptions thrown during response body stream reading are treated as retryable errors.

## Changes
- **`TdInputPlugin.java`**: Split `run()` into two phases:
  - Phase 1: Download job result to a temp file (td-client-java retry works correctly here — `REPLACE_EXISTING` overwrites partial data)
  - Phase 2: Read from local temp file and write to PageBuilder (no network errors possible)
- **`build.gradle`**: Add test dependencies (JUnit, Mockito, embulk-core)
- **`TestTdInputPlugin.java`**: Add 7 unit tests covering normal download, retry overwrite, multiple retries, mid-stream errors, and temp file cleanup

## Test plan
- [x] `./gradlew test` passes (7 tests, 0 failures)
- [x] `./gradlew compileJava` passes
- [ ] Deploy to canary environment and verify with 400M+ record transfer (no duplication)

Refs: https://github.com/primenumber-dev/n-transfer-ui/issues/42731

🤖 Generated with [Claude Code](https://claude.com/claude-code)